### PR TITLE
refactor: extract reusable record form

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1,7 +1,6 @@
 let state = {
   profiles: [],
   selected: new Set(),
-  selectedImages: [], // for image-mode record creation
 };
 
 function cssEscape(s){
@@ -165,58 +164,6 @@ function addImageResultsUnder(tbody, profileId, profileName, path, files){
   containerTd.appendChild(block);
 }
 
-function openRecordModal(profileId, path, line){
-  const modal = document.getElementById('recordModal');
-  const form = document.getElementById('recordForm');
-  form.reset();
-  form.profile_id.value = profileId;
-  const pathInput = form.querySelector('input[name="file_path"]'); if(pathInput) pathInput.value = path;
-  const view = document.getElementById('recordLineView'); if(view) view.value = line||'';
-  // text mode UI
-  document.getElementById('selectedImagesBlock').style.display='none';
-  document.getElementById('recordLineView').parentElement.style.display='block';
-  state.selectedImages = [];
-  document.getElementById('selectedImagesJson').value = '[]';
-  setNow(form.querySelector('input[name="event_dt"]'));
-  dbg('openRecordModal', {profileId, path});
-  modal.style.display='flex';
-}
-function openImageRecordModal(profileId, imagePath){
-  const modal = document.getElementById('recordModal');
-  const form = document.getElementById('recordForm');
-  form.reset();
-  form.profile_id.value = profileId;
-  const pathInput2 = form.querySelector('input[name="file_path"]'); if(pathInput2) pathInput2.value = imagePath;
-  const view2 = document.getElementById('recordLineView'); if(view2) view2.value = '';
-  document.getElementById('recordLineView').parentElement.style.display='block';
-  const block = document.getElementById('selectedImagesBlock');
-  const list = document.getElementById('selectedImagesList');
-  list.innerHTML = '';
-  state.selectedImages = [imagePath];
-  document.getElementById('selectedImagesJson').value = JSON.stringify(state.selectedImages);
-  const urls = state.selectedImages.map(p => `/api/profiles/${profileId}/image?path=${encodeURIComponent(p)}`);
-  urls.forEach((u, idx)=>{
-    const t = document.createElement('div'); t.className='thumb';
-    const im = document.createElement('img'); im.src = u; t.appendChild(im);
-    const meta = document.createElement('div'); meta.className='meta';
-    const si = document.createElement('span'); si.className='idx'; si.textContent = `#${idx+1}`; meta.appendChild(si);
-    const vb = document.createElement('button'); vb.type = 'button'; vb.textContent='View'; vb.onclick = ()=>{
-      const imgs = Array.from(document.querySelectorAll('#selectedImagesList img'));
-      const arr = imgs.map(el=> el.src);
-      const pos = arr.indexOf(u);
-      openImageViewer(arr, pos>=0?pos:0);
-    }; meta.appendChild(vb);
-    t.appendChild(meta); list.appendChild(t);
-  });
-  block.style.display='block';
-  setNow(form.querySelector('input[name="event_dt"]'));
-  dbg('openImageRecordModal', {profileId, imagePath});
-  modal.style.display='flex';
-}
-function closeRecordModal(){
-  const modal = document.getElementById('recordModal');
-  modal.style.display='none';
-}
 
 async function runAll(){
   const runBtn = document.getElementById('runAll');
@@ -318,49 +265,6 @@ document.addEventListener('DOMContentLoaded', ()=>{
         if(pth){ openImageRecordModal(pid, pth); }
       }
     });
-  }
-  const form = document.getElementById('recordForm');
-  const cancel = document.getElementById('recordCancel');
-  if(cancel) cancel.onclick = closeRecordModal;
-  if(form){
-    form.onsubmit = async (e)=>{
-      e.preventDefault();
-      const fd = new FormData(form);
-      const payload = {
-        profile_id: Number(fd.get('profile_id')),
-        title: String(fd.get('title')||''),
-        file_path: String(fd.get('file_path')||''),
-        filter: '',
-        content: String(fd.get('content')||''),
-        situation: String(fd.get('situation')||''),
-        event_time: (function(){ const dt = fd.get('event_dt'); if(!dt) return null; const t = Date.parse(dt); return isNaN(t)? null : Math.floor(t/1000); })(),
-        description: String(fd.get('description')||''),
-      };
-      const r = await fetch('/api/records',{method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)});
-      if(!r.ok){ alert('Failed to save record'); return; }
-      const rec = await r.json();
-      // upload selected remote images automatically
-      try{
-        const imgsSel = JSON.parse(document.getElementById('selectedImagesJson').value||'[]');
-        for(const rp of imgsSel){
-          await fetch(`/api/records/${rec.id}/image_remote`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ profile_id: payload.profile_id, path: rp }) });
-        }
-      }catch{}
-      const files = (document.querySelector('#recordForm input[name="images"]').files)||[];
-      for(const f of files){ const fdf = new FormData(); fdf.append('file', f); await fetch(`/api/records/${rec.id}/image`, { method:'POST', body: fdf }); }
-      closeRecordModal();
-      alert('Record saved');
-    };
-    // Local file preview when adding images before save
-    const fileInput = document.querySelector('#recordForm input[name="images"]');
-    if(fileInput){ fileInput.addEventListener('change', ()=>{
-      const list = document.getElementById('selectedImagesList');
-      const block = document.getElementById('selectedImagesBlock');
-      block.style.display='block';
-      for(const f of (fileInput.files||[])){
-        try{ const url = URL.createObjectURL(f); const t=document.createElement('div'); t.className='thumb'; const im=document.createElement('img'); im.src=url; t.appendChild(im); const m=document.createElement('div'); m.className='meta'; const s=document.createElement('span'); s.className='idx'; s.textContent=f.name; m.appendChild(s); const b=document.createElement('button'); b.type='button'; b.textContent='View'; b.onclick=()=>{ const imgs=Array.from(document.querySelectorAll('#selectedImagesList img')); const arr=imgs.map(el=>el.src); const pos=arr.indexOf(url); openImageViewer(arr, pos>=0?pos:0); }; m.appendChild(b); t.appendChild(m); list.appendChild(t); }catch{}
-      }
-    }); }
   }
 });
 

--- a/app/static/record_form.js
+++ b/app/static/record_form.js
@@ -1,0 +1,111 @@
+const RECORD_FORM_STATE = { selectedImages: [] };
+function setNow(inputEl){ if(!inputEl) return; try{ const d=new Date(); inputEl.value = new Date(d.getTime()-d.getTimezoneOffset()*60000).toISOString().slice(0,16); }catch{} }
+function openRecordForm(opts){
+  const modal = document.getElementById('recordModal');
+  const form = document.getElementById('recordForm');
+  if(!modal || !form) return;
+  form.reset();
+  const data = opts||{};
+  form.elements['id'].value = data.id||'';
+  form.elements['profile_id'].value = data.profile_id||'';
+  form.elements['file_path'].value = data.file_path||'';
+  form.elements['title'].value = data.title||'';
+  form.elements['content'].value = data.content||'';
+  form.elements['situation'].value = data.situation||'';
+  form.elements['description'].value = data.description||'';
+  if(data.event_time){ const dt=new Date(data.event_time*1000); form.elements['event_dt'].value = new Date(dt.getTime()-dt.getTimezoneOffset()*60000).toISOString().slice(0,16); }
+  else { setNow(form.elements['event_dt']); }
+  const titleEl = document.getElementById('recordModalTitle');
+  if(titleEl) titleEl.textContent = data.id? 'Record Detail' : 'Save Record';
+  const block = document.getElementById('selectedImagesBlock');
+  const list = document.getElementById('selectedImagesList');
+  list.innerHTML='';
+  RECORD_FORM_STATE.selectedImages = data.selectedImages||[];
+  if(data.images && data.images.length){
+    block.style.display='block';
+    data.images.forEach((img, idx)=>{
+      const t=document.createElement('div'); t.className='thumb';
+      const im=document.createElement('img'); im.src=img.url||img.path; t.appendChild(im);
+      const m=document.createElement('div'); m.className='meta';
+      const si=document.createElement('span'); si.className='idx'; si.textContent=img.id? `#${img.id}` : `#${idx+1}`; m.appendChild(si);
+      const vb=document.createElement('button'); vb.type='button'; vb.textContent='View'; vb.dataset.src=im.src; m.appendChild(vb);
+      if(img.id){ const rb=document.createElement('button'); rb.type='button'; rb.textContent='Remove'; rb.dataset.id=img.id; rb.style.borderColor='#991b1b'; m.appendChild(rb); }
+      t.appendChild(m); list.appendChild(t);
+    });
+  } else { block.style.display='none'; }
+  document.getElementById('selectedImagesJson').value = JSON.stringify(RECORD_FORM_STATE.selectedImages);
+  modal.style.display='flex';
+}
+function closeRecordForm(){ const modal=document.getElementById('recordModal'); if(modal) modal.style.display='none'; }
+document.addEventListener('DOMContentLoaded', ()=>{
+  const form=document.getElementById('recordForm');
+  const cancel=document.getElementById('recordCancel');
+  if(cancel) cancel.onclick=closeRecordForm;
+  if(form){
+    form.addEventListener('submit', async (e)=>{
+      e.preventDefault();
+      const fd=new FormData(form);
+      const id=fd.get('id');
+      const payload={
+        profile_id:Number(fd.get('profile_id')||0),
+        title:String(fd.get('title')||''),
+        file_path:String(fd.get('file_path')||''),
+        filter:'',
+        content:String(fd.get('content')||''),
+        situation:String(fd.get('situation')||''),
+        event_time:(function(){ const dt=fd.get('event_dt'); if(!dt) return null; const t=Date.parse(dt); return isNaN(t)? null: Math.floor(t/1000); })(),
+        description:String(fd.get('description')||''),
+      };
+      let rec=null;
+      if(id){
+        const r=await fetch(`/api/records/${id}`, { method:'PUT', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload) });
+        if(!r.ok){ alert('Save failed'); return; }
+        try{ rec=await r.json(); }catch{ rec={id}; }
+      } else {
+        const r=await fetch('/api/records', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload) });
+        if(!r.ok){ alert('Failed to save record'); return; }
+        rec=await r.json();
+        try{
+          const imgsSel=JSON.parse(document.getElementById('selectedImagesJson').value||'[]');
+          for(const rp of imgsSel){
+            await fetch(`/api/records/${rec.id}/image_remote`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ profile_id: payload.profile_id, path: rp }) });
+          }
+        }catch{}
+      }
+      const files=(form.querySelector('input[name="images"]').files)||[];
+      for(const f of files){ const fdf=new FormData(); fdf.append('file', f); await fetch(`/api/records/${rec.id}/image`, { method:'POST', body:fdf }); }
+      closeRecordForm();
+      document.dispatchEvent(new CustomEvent('recordFormSaved', { detail: rec }));
+      alert('Record saved');
+    });
+    const fileInput=form.querySelector('input[name="images"]');
+    if(fileInput){ fileInput.addEventListener('change', ()=>{
+      const list=document.getElementById('selectedImagesList');
+      const block=document.getElementById('selectedImagesBlock');
+      block.style.display='block';
+      for(const f of (fileInput.files||[])){
+        try{ const url=URL.createObjectURL(f); const t=document.createElement('div'); t.className='thumb'; const im=document.createElement('img'); im.src=url; t.appendChild(im); const m=document.createElement('div'); m.className='meta'; const s=document.createElement('span'); s.className='idx'; s.textContent=f.name; m.appendChild(s); const b=document.createElement('button'); b.type='button'; b.textContent='View'; b.onclick=()=>{ const imgs=Array.from(document.querySelectorAll('#selectedImagesList img')); const arr=imgs.map(el=>el.src); const pos=arr.indexOf(url); if(window.openImageViewer) openImageViewer(arr, pos>=0?pos:0); }; m.appendChild(b); t.appendChild(m); list.appendChild(t); }catch{}
+      }
+    }); }
+    document.getElementById('selectedImagesList').addEventListener('click', async (e)=>{
+      const btn=e.target.closest('button'); if(!btn) return;
+      if(btn.textContent==='View' && window.openImageViewer){
+        const imgs=Array.from(document.querySelectorAll('#selectedImagesList img')).map(el=>el.src);
+        const src=btn.dataset.src||btn.parentElement.previousSibling.src;
+        const idx=imgs.indexOf(src);
+        openImageViewer(imgs, idx>=0?idx:0);
+      }
+      if(btn.textContent==='Remove' && btn.dataset.id){
+        const iid=btn.dataset.id; const r=await fetch(`/api/record_images/${iid}`, { method:'DELETE' });
+        if(r.ok){ btn.closest('.thumb').remove(); }
+      }
+    });
+  }
+});
+function openRecordModal(profileId, path, line){
+  openRecordForm({ profile_id: profileId, file_path: path, content: line });
+}
+function openImageRecordModal(profileId, imagePath){
+  openRecordForm({ profile_id: profileId, file_path: imagePath, images:[{path:`/api/profiles/${profileId}/image?path=${encodeURIComponent(imagePath)}`}], selectedImages:[imagePath] });
+}
+function closeRecordModal(){ closeRecordForm(); }

--- a/app/templates/_record_form.html
+++ b/app/templates/_record_form.html
@@ -1,0 +1,43 @@
+<div id="recordModal" class="modal">
+  <div class="content">
+    <h3 id="recordModalTitle">Save Record</h3>
+    <form id="recordForm">
+      <input type="hidden" name="id" />
+      <input type="hidden" name="profile_id" />
+      <input type="hidden" name="selected_images_json" id="selectedImagesJson" />
+      <label>Path
+        <input type="text" name="file_path" readonly style="width:100%" />
+      </label>
+      <label>Title
+        <input type="text" name="title" placeholder="Optional title" style="width:100%" />
+      </label>
+      <div class="grid" style="grid-template-columns:1fr 1fr; gap:10px;">
+        <label>Date/Time
+          <input type="datetime-local" name="event_dt" />
+        </label>
+        <label>Situation
+          <input type="text" name="situation" placeholder="e.g., Incident, Debug, Note" />
+        </label>
+      </div>
+      <label>Description
+        <textarea name="description" placeholder="Describe context or steps" style="width:100%;height:80px"></textarea>
+      </label>
+      <label>Logs
+        <textarea id="recordLineView" name="content" placeholder="Log lines (for text records)" style="width:100%;height:100px"></textarea>
+      </label>
+      <div>
+        <strong>Images</strong>
+        <div id="selectedImagesBlock" style="display:none; margin:6px 0;">
+          <div id="selectedImagesList" class="panel" style="max-height:180px; overflow:auto"></div>
+        </div>
+        <div style="margin-top:6px;">
+          <input type="file" name="images" multiple accept="image/*" />
+        </div>
+      </div>
+      <div class="actions">
+        <button type="button" id="recordCancel">Cancel</button>
+        <button type="submit">Save</button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -48,48 +48,7 @@
       </section>
     </main>
     <!-- Record Modal -->
-    <div id="recordModal" class="modal">
-      <div class="content">
-        <h3>Save Record</h3>
-        <form id="recordForm">
-          <input type="hidden" name="profile_id" />
-          <input type="hidden" name="selected_images_json" id="selectedImagesJson" />
-          <label>Path
-            <input type="text" name="file_path" readonly style="width:100%" />
-          </label>
-          <label>Title
-            <input type="text" name="title" placeholder="Optional title" style="width:100%" />
-          </label>
-          <div class="grid" style="grid-template-columns:1fr 1fr; gap:10px;">
-            <label>Date/Time
-              <input type="datetime-local" name="event_dt" />
-            </label>
-            <label>Situation
-              <input type="text" name="situation" placeholder="e.g., Incident, Debug, Note" />
-            </label>
-          </div>
-          <label>Description
-            <textarea name="description" placeholder="Describe context or steps" style="width:100%;height:80px"></textarea>
-          </label>
-          <label>Logs
-            <textarea id="recordLineView" name="content" placeholder="Log lines (for text records)" style="width:100%;height:100px"></textarea>
-          </label>
-          <div>
-            <strong>Images</strong>
-            <div id="selectedImagesBlock" style="display:none; margin:6px 0;">
-              <div id="selectedImagesList" class="panel" style="max-height:180px; overflow:auto"></div>
-            </div>
-            <div style="margin-top:6px;">
-              <input type="file" name="images" multiple accept="image/*" />
-            </div>
-          </div>
-          <div class="actions">
-            <button type="button" id="recordCancel">Cancel</button>
-            <button type="submit">Save</button>
-          </div>
-        </form>
-      </div>
-    </div>
+    {% include '_record_form.html' %}
     <!-- Fullscreen Image Viewer -->
     <div id="imgViewer" class="img-viewer">
       <div class="inner">
@@ -112,6 +71,7 @@
     <script>
       window.APP_CFG = {{ (app_cfg or {'apiTimeoutMs':30000}) | tojson }};
     </script>
+    <script src="/static/record_form.js"></script>
     <script src="/static/app.js"></script>
   </body>
   </html>

--- a/app/templates/records.html
+++ b/app/templates/records.html
@@ -53,162 +53,92 @@
         <button class="nav next" id="imgViewNext">❯</button>
       </div>
     </div>
-    <!-- Record Detail Modal -->
-    <div id="recModal" class="modal">
-      <div class="content">
-        <h3>Record Detail</h3>
-        <form id="recForm">
-          <input type="hidden" name="id" />
-          <div class="grid" style="grid-template-columns:1fr 1fr; gap:10px;">
-            <label>Title
-              <input type="text" name="title" />
-            </label>
-            <label>Date/Time
-              <input type="datetime-local" name="event_dt" />
-            </label>
-          </div>
-          <label>Situation
-            <input type="text" name="situation" />
-          </label>
-          <label>Description
-            <textarea name="description" style="width:100%;height:90px"></textarea>
-          </label>
-          <div>
-            <strong>Images</strong>
-            <div id="recImgs" style="display:grid; grid-template-columns: repeat(auto-fill, 120px); gap:8px; margin:8px 0;"></div>
-            <div>
-              <input type="file" id="recAddImg" multiple accept="image/*" />
-              <button type="button" id="recAddImgBtn">Add Images</button>
-            </div>
-          </div>
-          <div class="actions">
-            <button type="button" id="recClose">Close</button>
-            <button type="submit">Save</button>
-          </div>
-        </form>
-      </div>
-    </div>
-    <script>
-      window.APP_CFG = {{ (app_cfg or {'apiTimeoutMs':30000}) | tojson }};
-      // mark active nav
-      (function(){
-        var path = location.pathname.replace(/\/+$/, '') || '/';
-        document.querySelectorAll('header nav a').forEach(function(a){
-          var href = a.getAttribute('href');
-          if(href === path) a.classList.add('active');
-        });
-      })();
-      // simple prefs
-      const PREF_NS='sshlt_';
-      function setPref(k,v){ try{ localStorage.setItem(PREF_NS+k, JSON.stringify(v)); }catch{} }
-      function getPref(k,d){ try{ const v=localStorage.getItem(PREF_NS+k); return v? JSON.parse(v): d; }catch{ return d; } }
-      let PROFILES=[];
-      let PROFILE_ID=getPref('records.PROFILE_ID','all');
-      async function loadProfiles(){
-        const d = await (await fetch('/api/profiles')).json();
-        PROFILES = d.profiles||[];
-        const sel = document.getElementById('profileSelect'); sel.innerHTML='';
-        sel.add(new Option('All profiles','all'));
-        PROFILES.forEach(p=> sel.add(new Option(p.name, p.id)));
-        sel.value = PROFILE_ID;
-      }
-      async function load(){
-        const r = await fetch('/api/records'); const data = await r.json();
-        const pm = {}; PROFILES.forEach(p=>pm[p.id]=p.name);
-        const tb = document.querySelector('#tbl tbody'); tb.innerHTML='';
-        (data.records||[])
-          .filter(rec => PROFILE_ID==='all' || rec.profile_id===Number(PROFILE_ID))
-          .forEach(rec=>{
-            const tr = document.createElement('tr');
-            const imgs = (rec.images||[]).map(i=>`<a href=\"${i.url||i.path}\" target=\"_blank\">img#${i.id}</a>`).join(', ');
-            const created = new Date((rec.created_at||0)*1000).toLocaleString();
-            const situationDate = rec.event_time ? new Date(rec.event_time*1000).toLocaleString() : '';
-            const logs = (rec.content||'').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-            const situation = rec.situation||'';
-            const desc = (rec.description||'').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-            tr.innerHTML = `<td>${rec.id}</td><td>${pm[rec.profile_id]||''}</td><td>${rec.file_path||''}</td><td>${logs}</td><td>${rec.title||''}</td><td>${situation}</td><td>${desc}</td><td>${imgs}</td><td>${situationDate}</td><td>${created}</td><td><button data-act=\"del\" data-id=\"${rec.id}\" style=\"border-color:#991b1b\">Delete</button></td>`;
-            tr.addEventListener('click', (ev)=>{ if(ev.target.closest('button')) return; openDetail(rec); });
-            tb.appendChild(tr);
-          });
-      }
-      document.getElementById('tbl').addEventListener('click', async (e)=>{
-        const btn = e.target.closest('button'); if(!btn) return;
-        if(btn.dataset.act==='del'){
-          if(!confirm('Delete this record?')) return;
-          const rid = btn.dataset.id; const r = await fetch(`/api/records/${rid}`, { method:'DELETE' });
-          if(r.ok){ load(); } else { alert('Delete failed'); }
-        }
+    {% include '_record_form.html' %}
+    <script src="/static/record_form.js"></script>
+<script>
+  window.APP_CFG = {{ (app_cfg or {'apiTimeoutMs':30000}) | tojson }};
+  // mark active nav
+  (function(){
+    var path = location.pathname.replace(/\/+$/, '') || '/';
+    document.querySelectorAll('header nav a').forEach(function(a){
+      var href = a.getAttribute('href');
+      if(href === path) a.classList.add('active');
+    });
+  })();
+  // simple prefs
+  const PREF_NS='sshlt_';
+  function setPref(k,v){ try{ localStorage.setItem(PREF_NS+k, JSON.stringify(v)); }catch{} }
+  function getPref(k,d){ try{ const v=localStorage.getItem(PREF_NS+k); return v? JSON.parse(v): d; }catch{ return d; } }
+  let PROFILES=[];
+  let PROFILE_ID=getPref('records.PROFILE_ID','all');
+  async function loadProfiles(){
+    const d = await (await fetch('/api/profiles')).json();
+    PROFILES = d.profiles||[];
+    const sel = document.getElementById('profileSelect'); sel.innerHTML='';
+    sel.add(new Option('All profiles','all'));
+    PROFILES.forEach(p=> sel.add(new Option(p.name, p.id)));
+    sel.value = PROFILE_ID;
+  }
+  async function load(){
+    const r = await fetch('/api/records'); const data = await r.json();
+    const pm = {}; PROFILES.forEach(p=>pm[p.id]=p.name);
+    const tb = document.querySelector('#tbl tbody'); tb.innerHTML='';
+    (data.records||[])
+      .filter(rec => PROFILE_ID==='all' || rec.profile_id===Number(PROFILE_ID))
+      .forEach(rec=>{
+        const tr = document.createElement('tr');
+        const imgs = (rec.images||[]).map(i=>`<a href=\"${i.url||i.path}\" target=\"_blank\">img#${i.id}</a>`).join(', ');
+        const created = new Date((rec.created_at||0)*1000).toLocaleString();
+        const situationDate = rec.event_time ? new Date(rec.event_time*1000).toLocaleString() : '';
+        const logs = (rec.content||'').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+        const situation = rec.situation||'';
+        const desc = (rec.description||'').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+        tr.innerHTML = `<td>${rec.id}</td><td>${pm[rec.profile_id]||''}</td><td>${rec.file_path||''}</td><td>${logs}</td><td>${rec.title||''}</td><td>${situation}</td><td>${desc}</td><td>${imgs}</td><td>${situationDate}</td><td>${created}</td><td><button data-act=\"del\" data-id=\"${rec.id}\" style=\"border-color:#991b1b\">Delete</button></td>`;
+        tr.addEventListener('click', (ev)=>{ if(ev.target.closest('button')) return; openDetail(rec); });
+        tb.appendChild(tr);
       });
-      function openDetail(rec){
-        const modal = document.getElementById('recModal');
-        const form = document.getElementById('recForm');
-        form.elements['id'].value = rec.id;
-        if(form.elements['path_ro']) form.elements['path_ro'].value = rec.file_path||'';
-        form.elements['title'].value = rec.title||'';
-        form.elements['situation'].value = rec.situation||'';
-        form.elements['description'].value = rec.description||'';
-        if(rec.event_time){ const dt = new Date(rec.event_time*1000); form.elements['event_dt'].value = new Date(dt.getTime()-dt.getTimezoneOffset()*60000).toISOString().slice(0,16); } else { form.elements['event_dt'].value=''; }
-        const grid = document.getElementById('recImgs'); grid.innerHTML='';
-        (rec.images||[]).forEach(img=>{
-          const wrap = document.createElement('div'); wrap.className='thumb';
-          wrap.innerHTML = `<img src="${img.url||img.path}" loading="lazy"><div class="meta"><span class="idx">#${img.id}</span><button type="button" data-act="imgview" data-src="${img.url||img.path}">View</button><button type="button" data-act="imgdel" data-id="${img.id}" style="border-color:#991b1b">Remove</button></div>`;
-          grid.appendChild(wrap);
-        });
-        modal.style.display='flex';
-      }
-      document.getElementById('recClose').addEventListener('click', ()=>{ document.getElementById('recModal').style.display='none'; });
-      document.getElementById('recForm').addEventListener('submit', async (e)=>{
-        e.preventDefault();
-        const f = e.target;
-        const payload = {
-          title: f.elements['title'].value,
-          situation: f.elements['situation'].value,
-          description: f.elements['description'].value,
-          event_time: (function(){ const v=f.elements['event_dt'].value; if(!v) return null; const t=Date.parse(v); return isNaN(t)? null : Math.floor(t/1000); })(),
-        };
-        const rid = f.elements['id'].value;
-        const r = await fetch(`/api/records/${rid}`, { method:'PUT', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload) });
-        if(r.ok){ alert('Saved'); document.getElementById('recModal').style.display='none'; load(); } else { alert('Save failed'); }
-      });
-      document.getElementById('recImgs').addEventListener('click', async (e)=>{
-        const btn = e.target.closest('button'); if(!btn) return;
-        if(btn.dataset.act==='imgview'){
-          const grid = document.getElementById('recImgs');
-          const urls = [...grid.querySelectorAll('img')].map(im=> im.getAttribute('src'));
-          const src = btn.dataset.src; const idx = urls.indexOf(src);
-          openImageViewer(urls, idx>=0?idx:0);
-          return;
-        }
-        if(btn.dataset.act==='imgdel'){
-          const iid = btn.dataset.id; const r = await fetch(`/api/record_images/${iid}`, { method:'DELETE' });
-          if(r.ok){ load(); document.getElementById('recModal').style.display='none'; }
-        }
-      });
-      document.getElementById('recAddImgBtn').addEventListener('click', async ()=>{
-        const input = document.getElementById('recAddImg'); const rid = document.getElementById('recForm').elements['id'].value;
-        const files = input.files||[]; if(!files.length) return;
-        for(const f of files){ const fd = new FormData(); fd.append('file', f); await fetch(`/api/records/${rid}/image`, { method:'POST', body: fd }); }
-        alert('Images added'); document.getElementById('recModal').style.display='none'; load();
-      });
-      document.getElementById('profileSelect').addEventListener('change', (e)=>{ PROFILE_ID = e.target.value; setPref('records.PROFILE_ID', PROFILE_ID); load(); });
-      (async ()=>{ await loadProfiles(); await load(); })();
-      // viewer fn (shared with Logs page)
-      let IMG_VIEW = { arr: [], idx: 0 };
-      function openImageViewer(arr, start){
-        try{ IMG_VIEW.arr = arr||[]; IMG_VIEW.idx = Math.max(0, Math.min(start||0, IMG_VIEW.arr.length-1)); }catch{ IMG_VIEW={arr:[], idx:0}; }
-        const wrap = document.getElementById('imgViewer'); const img = document.getElementById('imgViewImg');
-        if(!wrap||!img) return;
-        const render = ()=>{ img.src = IMG_VIEW.arr[IMG_VIEW.idx]||''; };
-        render();
-        wrap.style.display='flex';
-        const prev = document.getElementById('imgViewPrev'); const next = document.getElementById('imgViewNext'); const close = document.getElementById('imgViewClose');
-        if(prev) prev.onclick = (e)=>{ e.stopPropagation(); if(IMG_VIEW.idx>0){ IMG_VIEW.idx--; render(); } };
-        if(next) next.onclick = (e)=>{ e.stopPropagation(); if(IMG_VIEW.idx<IMG_VIEW.arr.length-1){ IMG_VIEW.idx++; render(); } };
-        if(close) close.onclick = ()=>{ wrap.style.display='none'; };
-        wrap.onclick = ()=>{ wrap.style.display='none'; };
-        function esc(e){ if(e.key==='Escape'){ wrap.style.display='none'; document.removeEventListener('keydown', esc);} if(e.key==='ArrowLeft'){ if(IMG_VIEW.idx>0){ IMG_VIEW.idx--; render(); } } if(e.key==='ArrowRight'){ if(IMG_VIEW.idx<IMG_VIEW.arr.length-1){ IMG_VIEW.idx++; render(); } } }
-        document.addEventListener('keydown', esc);
-      }
-    </script>
-  </body>
+  }
+  document.getElementById('tbl').addEventListener('click', async (e)=>{
+    const btn = e.target.closest('button'); if(!btn) return;
+    if(btn.dataset.act==='del'){
+      if(!confirm('Delete this record?')) return;
+      const rid = btn.dataset.id; const r = await fetch(`/api/records/${rid}`, { method:'DELETE' });
+      if(r.ok){ load(); } else { alert('Delete failed'); }
+    }
+  });
+  function openDetail(rec){
+    openRecordForm({
+      id: rec.id,
+      profile_id: rec.profile_id,
+      file_path: rec.file_path || '',
+      title: rec.title || '',
+      situation: rec.situation || '',
+      description: rec.description || '',
+      content: rec.content || '',
+      event_time: rec.event_time || null,
+      images: rec.images || []
+    });
+  }
+  document.addEventListener('recordFormSaved', load);
+  document.getElementById('profileSelect').addEventListener('change', (e)=>{ PROFILE_ID = e.target.value; setPref('records.PROFILE_ID', PROFILE_ID); load(); });
+  (async ()=>{ await loadProfiles(); await load(); })();
+  // viewer fn (shared with Logs page)
+  let IMG_VIEW = { arr: [], idx: 0 };
+  function openImageViewer(arr, start){
+    try{ IMG_VIEW.arr = arr||[]; IMG_VIEW.idx = Math.max(0, Math.min(start||0, IMG_VIEW.arr.length-1)); }catch{ IMG_VIEW={arr:[], idx:0}; }
+    const wrap = document.getElementById('imgViewer'); const img = document.getElementById('imgViewImg');
+    if(!wrap||!img) return;
+    const render = ()=>{ img.src = IMG_VIEW.arr[IMG_VIEW.idx]||''; };
+    render();
+    wrap.style.display='flex';
+    const prev = document.getElementById('imgViewPrev'); const next = document.getElementById('imgViewNext'); const close =document.getElementById('imgViewClose');
+    if(prev) prev.onclick = (e)=>{ e.stopPropagation(); if(IMG_VIEW.idx>0){ IMG_VIEW.idx--; render(); } };
+    if(next) next.onclick = (e)=>{ e.stopPropagation(); if(IMG_VIEW.idx<IMG_VIEW.arr.length-1){ IMG_VIEW.idx++; render(); } };
+    if(close) close.onclick = ()=>{ wrap.style.display='none'; };
+    wrap.onclick = ()=>{ wrap.style.display='none'; };
+    function esc(e){ if(e.key==='Escape'){ wrap.style.display='none'; document.removeEventListener('keydown', esc);} if(e.key==='ArrowLeft'){ if(IMG_VIEW.idx>0){ IMG_VIEW.idx--; render(); } } if(e.key==='ArrowRight'){ if(IMG_VIEW.idx<IMG_VIEW.arr.length-1){ IMG_VIEW.idx++; render(); } } }
+    document.addEventListener('keydown', esc);
+  }
+</script>
+</body>
   </html>

--- a/context.md
+++ b/context.md
@@ -81,6 +81,7 @@ Notes:
 - Handlers: Rotating file handler respects `max_bytes` and `backup_count`; optional console handler with configurable level. Rotated files are prefixed with the index, e.g., `1-YYYY-MM-DD.log`.
 
 ## 6) Change Journal (append newest on top)
+- 2025-08-31 — Extracted record form modal into reusable widget shared by Logs and Records pages; added record_form.js and template.
 - 2025-08-30 — Switched to tray-only mode (no taskbar entry); control panel is shown/hidden via tray icon (default menu/double-click).
 - 2025-08-30 — Control panel redesign: colorful theme, status indicator, Start/Stop buttons auto-enable/disable, optional custom icon via `ui.icon_path`.
 - 2025-08-30 — Added optional startup control panel (diagnostic popup) with Start/Stop/Open/Minimize/Exit; configurable via `ui.*` in config.json.

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -28,9 +28,11 @@ CTX_PRIORITY_MODE: recent-first
 │  ├─ templates/
 │  │  ├─ index.html            # Logs page (SPA shell)
 │  │  ├─ profiles.html         # Profiles management (SSH/FTP)
-│  │  └─ records.html          # Records browse/upload
+│  │  ├─ records.html          # Records browse/upload
+│  │  └─ _record_form.html     # Reusable record form modal
 │  └─ static/
 │     ├─ app.js                # Logs page UI logic
+│     ├─ record_form.js        # Shared record form behaviors
 │     └─ style.css             # Styles
 ├─ docs/
 │  ├─ env.md

--- a/docs/module-architecture.md
+++ b/docs/module-architecture.md
@@ -27,7 +27,9 @@ graph TD
     T[templates/index.html]
     TP[templates/profiles.html]
     TR[templates/records.html]
+    TF[templates/_record_form.html]
     S[static/app.js]
+    RF[static/record_form.js]
     CSS[static/style.css]
   end
 
@@ -43,6 +45,10 @@ graph TD
   F --> TP
   F --> TR
   T --> S
+  T --> RF
+  TR --> RF
+  T --> TF
+  TR --> TF
   T --> CSS
   TP --> CSS
   TR --> CSS


### PR DESCRIPTION
## Summary
- factor out the Record form into `_record_form.html` and shared `record_form.js`
- wire logs and records pages to use the new reusable modal widget
- document new widget in code architecture and module graph

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b475e1160c8320bd7f708db60d16d1