### PR TITLE
feat(ui): reuse record form widget

### DIFF
--- a/app/templates/components/record_form.html
+++ b/app/templates/components/record_form.html
@@ -1,0 +1,32 @@
+{% macro record_form(action_label='Save') %}
+<form id="recordForm">
+  <input type="hidden" name="id" />
+  <input type="hidden" name="profile_id" />
+  <input type="hidden" name="selected_images_json" id="selectedImagesJson" />
+  <label>Path
+    <input type="text" name="file_path" readonly style="width:100%" />
+  </label>
+  <label>Title
+    <input type="text" name="title" placeholder="Optional title" style="width:100%" />
+  </label>
+  <div class="grid" style="grid-template-columns:1fr 1fr; gap:10px;">
+    <label>Date/Time
+      <input type="datetime-local" name="event_dt" />
+    </label>
+    <label>Situation
+      <input type="text" name="situation" placeholder="e.g., Incident, Debug, Note" />
+    </label>
+  </div>
+  <label>Description
+    <textarea name="description" placeholder="Describe context or steps" style="width:100%;height:80px"></textarea>
+  </label>
+  <label>Logs
+    <textarea id="recordLineView" name="content" placeholder="Log lines (for text records)" style="width:100%;height:100px"></textarea>
+  </label>
+  {{ caller() }}
+  <div class="actions">
+    <button type="button" id="recordCancel">Cancel</button>
+    <button type="submit">{{ action_label }}</button>
+  </div>
+</form>
+{% endmacro %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -47,33 +47,12 @@
         </div>
       </section>
     </main>
+    {% from 'components/record_form.html' import record_form %}
     <!-- Record Modal -->
     <div id="recordModal" class="modal">
       <div class="content">
         <h3>Save Record</h3>
-        <form id="recordForm">
-          <input type="hidden" name="profile_id" />
-          <input type="hidden" name="selected_images_json" id="selectedImagesJson" />
-          <label>Path
-            <input type="text" name="file_path" readonly style="width:100%" />
-          </label>
-          <label>Title
-            <input type="text" name="title" placeholder="Optional title" style="width:100%" />
-          </label>
-          <div class="grid" style="grid-template-columns:1fr 1fr; gap:10px;">
-            <label>Date/Time
-              <input type="datetime-local" name="event_dt" />
-            </label>
-            <label>Situation
-              <input type="text" name="situation" placeholder="e.g., Incident, Debug, Note" />
-            </label>
-          </div>
-          <label>Description
-            <textarea name="description" placeholder="Describe context or steps" style="width:100%;height:80px"></textarea>
-          </label>
-          <label>Logs
-            <textarea id="recordLineView" name="content" placeholder="Log lines (for text records)" style="width:100%;height:100px"></textarea>
-          </label>
+        {% call record_form() %}
           <div>
             <strong>Images</strong>
             <div id="selectedImagesBlock" style="display:none; margin:6px 0;">
@@ -83,11 +62,7 @@
               <input type="file" name="images" multiple accept="image/*" />
             </div>
           </div>
-          <div class="actions">
-            <button type="button" id="recordCancel">Cancel</button>
-            <button type="submit">Save</button>
-          </div>
-        </form>
+        {% endcall %}
       </div>
     </div>
     <!-- Fullscreen Image Viewer -->

--- a/app/templates/records.html
+++ b/app/templates/records.html
@@ -53,39 +53,21 @@
         <button class="nav next" id="imgViewNext">❯</button>
       </div>
     </div>
+    {% from 'components/record_form.html' import record_form %}
     <!-- Record Detail Modal -->
-    <div id="recModal" class="modal">
+    <div id="recordModal" class="modal">
       <div class="content">
         <h3>Record Detail</h3>
-        <form id="recForm">
-          <input type="hidden" name="id" />
-          <div class="grid" style="grid-template-columns:1fr 1fr; gap:10px;">
-            <label>Title
-              <input type="text" name="title" />
-            </label>
-            <label>Date/Time
-              <input type="datetime-local" name="event_dt" />
-            </label>
-          </div>
-          <label>Situation
-            <input type="text" name="situation" />
-          </label>
-          <label>Description
-            <textarea name="description" style="width:100%;height:90px"></textarea>
-          </label>
+        {% call record_form() %}
           <div>
             <strong>Images</strong>
-            <div id="recImgs" style="display:grid; grid-template-columns: repeat(auto-fill, 120px); gap:8px; margin:8px 0;"></div>
+            <div id="recordImgs" style="display:grid; grid-template-columns: repeat(auto-fill, 120px); gap:8px; margin:8px 0;"></div>
             <div>
-              <input type="file" id="recAddImg" multiple accept="image/*" />
-              <button type="button" id="recAddImgBtn">Add Images</button>
+              <input type="file" id="recordAddImg" multiple accept="image/*" />
+              <button type="button" id="recordAddImgBtn">Add Images</button>
             </div>
           </div>
-          <div class="actions">
-            <button type="button" id="recClose">Close</button>
-            <button type="submit">Save</button>
-          </div>
-        </form>
+        {% endcall %}
       </div>
     </div>
     <script>
@@ -140,15 +122,16 @@
         }
       });
       function openDetail(rec){
-        const modal = document.getElementById('recModal');
-        const form = document.getElementById('recForm');
+        const modal = document.getElementById('recordModal');
+        const form = document.getElementById('recordForm');
         form.elements['id'].value = rec.id;
-        if(form.elements['path_ro']) form.elements['path_ro'].value = rec.file_path||'';
+        if(form.elements['file_path']) form.elements['file_path'].value = rec.file_path||'';
+        if(form.elements['content']) form.elements['content'].value = rec.content||'';
         form.elements['title'].value = rec.title||'';
         form.elements['situation'].value = rec.situation||'';
         form.elements['description'].value = rec.description||'';
         if(rec.event_time){ const dt = new Date(rec.event_time*1000); form.elements['event_dt'].value = new Date(dt.getTime()-dt.getTimezoneOffset()*60000).toISOString().slice(0,16); } else { form.elements['event_dt'].value=''; }
-        const grid = document.getElementById('recImgs'); grid.innerHTML='';
+        const grid = document.getElementById('recordImgs'); grid.innerHTML='';
         (rec.images||[]).forEach(img=>{
           const wrap = document.createElement('div'); wrap.className='thumb';
           wrap.innerHTML = `<img src="${img.url||img.path}" loading="lazy"><div class="meta"><span class="idx">#${img.id}</span><button type="button" data-act="imgview" data-src="${img.url||img.path}">View</button><button type="button" data-act="imgdel" data-id="${img.id}" style="border-color:#991b1b">Remove</button></div>`;
@@ -156,8 +139,8 @@
         });
         modal.style.display='flex';
       }
-      document.getElementById('recClose').addEventListener('click', ()=>{ document.getElementById('recModal').style.display='none'; });
-      document.getElementById('recForm').addEventListener('submit', async (e)=>{
+      document.getElementById('recordCancel').addEventListener('click', ()=>{ document.getElementById('recordModal').style.display='none'; });
+      document.getElementById('recordForm').addEventListener('submit', async (e)=>{
         e.preventDefault();
         const f = e.target;
         const payload = {
@@ -168,12 +151,12 @@
         };
         const rid = f.elements['id'].value;
         const r = await fetch(`/api/records/${rid}`, { method:'PUT', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload) });
-        if(r.ok){ alert('Saved'); document.getElementById('recModal').style.display='none'; load(); } else { alert('Save failed'); }
+          if(r.ok){ alert('Saved'); document.getElementById('recordModal').style.display='none'; load(); } else { alert('Save failed'); }
       });
-      document.getElementById('recImgs').addEventListener('click', async (e)=>{
+      document.getElementById('recordImgs').addEventListener('click', async (e)=>{
         const btn = e.target.closest('button'); if(!btn) return;
         if(btn.dataset.act==='imgview'){
-          const grid = document.getElementById('recImgs');
+          const grid = document.getElementById('recordImgs');
           const urls = [...grid.querySelectorAll('img')].map(im=> im.getAttribute('src'));
           const src = btn.dataset.src; const idx = urls.indexOf(src);
           openImageViewer(urls, idx>=0?idx:0);
@@ -181,14 +164,14 @@
         }
         if(btn.dataset.act==='imgdel'){
           const iid = btn.dataset.id; const r = await fetch(`/api/record_images/${iid}`, { method:'DELETE' });
-          if(r.ok){ load(); document.getElementById('recModal').style.display='none'; }
+          if(r.ok){ load(); document.getElementById('recordModal').style.display='none'; }
         }
       });
-      document.getElementById('recAddImgBtn').addEventListener('click', async ()=>{
-        const input = document.getElementById('recAddImg'); const rid = document.getElementById('recForm').elements['id'].value;
+      document.getElementById('recordAddImgBtn').addEventListener('click', async ()=>{
+        const input = document.getElementById('recordAddImg'); const rid = document.getElementById('recordForm').elements['id'].value;
         const files = input.files||[]; if(!files.length) return;
         for(const f of files){ const fd = new FormData(); fd.append('file', f); await fetch(`/api/records/${rid}/image`, { method:'POST', body: fd }); }
-        alert('Images added'); document.getElementById('recModal').style.display='none'; load();
+        alert('Images added'); document.getElementById('recordModal').style.display='none'; load();
       });
       document.getElementById('profileSelect').addEventListener('change', (e)=>{ PROFILE_ID = e.target.value; setPref('records.PROFILE_ID', PROFILE_ID); load(); });
       (async ()=>{ await loadProfiles(); await load(); })();

--- a/context.md
+++ b/context.md
@@ -81,6 +81,7 @@ Notes:
 - Handlers: Rotating file handler respects `max_bytes` and `backup_count`; optional console handler with configurable level. Rotated files are prefixed with the index, e.g., `1-YYYY-MM-DD.log`.
 
 ## 6) Change Journal (append newest on top)
+- 2025-08-31 — Added reusable record form widget shared by Logs and Records pages.
 - 2025-08-30 — Switched to tray-only mode (no taskbar entry); control panel is shown/hidden via tray icon (default menu/double-click).
 - 2025-08-30 — Control panel redesign: colorful theme, status indicator, Start/Stop buttons auto-enable/disable, optional custom icon via `ui.icon_path`.
 - 2025-08-30 — Added optional startup control panel (diagnostic popup) with Start/Stop/Open/Minimize/Exit; configurable via `ui.*` in config.json.

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -28,7 +28,9 @@ CTX_PRIORITY_MODE: recent-first
 │  ├─ templates/
 │  │  ├─ index.html            # Logs page (SPA shell)
 │  │  ├─ profiles.html         # Profiles management (SSH/FTP)
-│  │  └─ records.html          # Records browse/upload
+│  │  ├─ records.html          # Records browse/upload
+│  │  └─ components/
+│  │     └─ record_form.html   # Reusable record form widget (Jinja macro)
 │  └─ static/
 │     ├─ app.js                # Logs page UI logic
 │     └─ style.css             # Styles
@@ -57,6 +59,7 @@ CTX_PRIORITY_MODE: recent-first
 - app/db.py: SQLite schema init and helpers (profiles, profile_paths, records, record_images).
 - app/views.py: Serves index.html, profiles.html, records.html.
 - templates + static: Simple pages calling REST endpoints.
+- templates/components/record_form.html: Shared record form widget used by logs and records pages.
 
 ## External Dependencies
 - Flask, Werkzeug: web server and routing

--- a/docs/module-architecture.md
+++ b/docs/module-architecture.md
@@ -27,6 +27,7 @@ graph TD
     T[templates/index.html]
     TP[templates/profiles.html]
     TR[templates/records.html]
+    RF[templates/components/record_form.html]
     S[static/app.js]
     CSS[static/style.css]
   end
@@ -46,6 +47,8 @@ graph TD
   T --> CSS
   TP --> CSS
   TR --> CSS
+  T --> RF
+  TR --> RF
 
   subgraph Communication Layer
     API[/HTTP: /api/.../]


### PR DESCRIPTION
## Summary
- add `record_form` Jinja macro for log/record modals
- refactor Logs and Records pages to include the shared form
- document reusable widget in architecture docs and context

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b475e1160c8320bd7f708db60d16d1