### PR TITLE
refactor: add reusable record modal

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1,7 +1,6 @@
 let state = {
   profiles: [],
   selected: new Set(),
-  selectedImages: [], // for image-mode record creation
 };
 
 function cssEscape(s){
@@ -163,60 +162,6 @@ function addImageResultsUnder(tbody, profileId, profileName, path, files){
     tbl.style.display = (tbl.style.display==='none')? '' : 'none';
   });
   containerTd.appendChild(block);
-}
-
-function openRecordModal(profileId, path, line){
-  const modal = document.getElementById('recordModal');
-  const form = document.getElementById('recordForm');
-  form.reset();
-  form.profile_id.value = profileId;
-  const pathInput = form.querySelector('input[name="file_path"]'); if(pathInput) pathInput.value = path;
-  const view = document.getElementById('recordLineView'); if(view) view.value = line||'';
-  // text mode UI
-  document.getElementById('selectedImagesBlock').style.display='none';
-  document.getElementById('recordLineView').parentElement.style.display='block';
-  state.selectedImages = [];
-  document.getElementById('selectedImagesJson').value = '[]';
-  setNow(form.querySelector('input[name="event_dt"]'));
-  dbg('openRecordModal', {profileId, path});
-  modal.style.display='flex';
-}
-function openImageRecordModal(profileId, imagePath){
-  const modal = document.getElementById('recordModal');
-  const form = document.getElementById('recordForm');
-  form.reset();
-  form.profile_id.value = profileId;
-  const pathInput2 = form.querySelector('input[name="file_path"]'); if(pathInput2) pathInput2.value = imagePath;
-  const view2 = document.getElementById('recordLineView'); if(view2) view2.value = '';
-  document.getElementById('recordLineView').parentElement.style.display='block';
-  const block = document.getElementById('selectedImagesBlock');
-  const list = document.getElementById('selectedImagesList');
-  list.innerHTML = '';
-  state.selectedImages = [imagePath];
-  document.getElementById('selectedImagesJson').value = JSON.stringify(state.selectedImages);
-  const urls = state.selectedImages.map(p => `/api/profiles/${profileId}/image?path=${encodeURIComponent(p)}`);
-  urls.forEach((u, idx)=>{
-    const t = document.createElement('div'); t.className='thumb';
-    const im = document.createElement('img'); im.src = u; t.appendChild(im);
-    const meta = document.createElement('div'); meta.className='meta';
-    const si = document.createElement('span'); si.className='idx'; si.textContent = `#${idx+1}`; meta.appendChild(si);
-    const vb = document.createElement('button'); vb.type = 'button'; vb.textContent='View'; vb.onclick = ()=>{
-      const imgs = Array.from(document.querySelectorAll('#selectedImagesList img'));
-      const arr = imgs.map(el=> el.src);
-      const pos = arr.indexOf(u);
-      openImageViewer(arr, pos>=0?pos:0);
-    }; meta.appendChild(vb);
-    t.appendChild(meta); list.appendChild(t);
-  });
-  block.style.display='block';
-  setNow(form.querySelector('input[name="event_dt"]'));
-  dbg('openImageRecordModal', {profileId, imagePath});
-  modal.style.display='flex';
-}
-function closeRecordModal(){
-  const modal = document.getElementById('recordModal');
-  modal.style.display='none';
-}
 
 async function runAll(){
   const runBtn = document.getElementById('runAll');
@@ -318,49 +263,6 @@ document.addEventListener('DOMContentLoaded', ()=>{
         if(pth){ openImageRecordModal(pid, pth); }
       }
     });
-  }
-  const form = document.getElementById('recordForm');
-  const cancel = document.getElementById('recordCancel');
-  if(cancel) cancel.onclick = closeRecordModal;
-  if(form){
-    form.onsubmit = async (e)=>{
-      e.preventDefault();
-      const fd = new FormData(form);
-      const payload = {
-        profile_id: Number(fd.get('profile_id')),
-        title: String(fd.get('title')||''),
-        file_path: String(fd.get('file_path')||''),
-        filter: '',
-        content: String(fd.get('content')||''),
-        situation: String(fd.get('situation')||''),
-        event_time: (function(){ const dt = fd.get('event_dt'); if(!dt) return null; const t = Date.parse(dt); return isNaN(t)? null : Math.floor(t/1000); })(),
-        description: String(fd.get('description')||''),
-      };
-      const r = await fetch('/api/records',{method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)});
-      if(!r.ok){ alert('Failed to save record'); return; }
-      const rec = await r.json();
-      // upload selected remote images automatically
-      try{
-        const imgsSel = JSON.parse(document.getElementById('selectedImagesJson').value||'[]');
-        for(const rp of imgsSel){
-          await fetch(`/api/records/${rec.id}/image_remote`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ profile_id: payload.profile_id, path: rp }) });
-        }
-      }catch{}
-      const files = (document.querySelector('#recordForm input[name="images"]').files)||[];
-      for(const f of files){ const fdf = new FormData(); fdf.append('file', f); await fetch(`/api/records/${rec.id}/image`, { method:'POST', body: fdf }); }
-      closeRecordModal();
-      alert('Record saved');
-    };
-    // Local file preview when adding images before save
-    const fileInput = document.querySelector('#recordForm input[name="images"]');
-    if(fileInput){ fileInput.addEventListener('change', ()=>{
-      const list = document.getElementById('selectedImagesList');
-      const block = document.getElementById('selectedImagesBlock');
-      block.style.display='block';
-      for(const f of (fileInput.files||[])){
-        try{ const url = URL.createObjectURL(f); const t=document.createElement('div'); t.className='thumb'; const im=document.createElement('img'); im.src=url; t.appendChild(im); const m=document.createElement('div'); m.className='meta'; const s=document.createElement('span'); s.className='idx'; s.textContent=f.name; m.appendChild(s); const b=document.createElement('button'); b.type='button'; b.textContent='View'; b.onclick=()=>{ const imgs=Array.from(document.querySelectorAll('#selectedImagesList img')); const arr=imgs.map(el=>el.src); const pos=arr.indexOf(url); openImageViewer(arr, pos>=0?pos:0); }; m.appendChild(b); t.appendChild(m); list.appendChild(t); }catch{}
-      }
-    }); }
   }
 });
 

--- a/app/static/record-modal.js
+++ b/app/static/record-modal.js
@@ -1,0 +1,166 @@
+let REC_STATE = { selectedImages: [] };
+
+function setNow(inputEl){ if(!inputEl) return; try{ const d=new Date(); inputEl.value = new Date(d.getTime()-d.getTimezoneOffset()*60000).toISOString().slice(0,16); }catch{} }
+
+async function fetchJSON(url, opts){
+  const timeoutMs = (window.APP_CFG && Number(window.APP_CFG.apiTimeoutMs)) || 30000;
+  const ctrl = new AbortController();
+  const t = setTimeout(()=> ctrl.abort(), timeoutMs);
+  try{
+    const r = await fetch(url, Object.assign({ signal: ctrl.signal }, opts||{}));
+    let data = {}; try{ data = await r.json(); }catch{}
+    return { ok: r.ok, data, status: r.status };
+  }catch(e){
+    return { ok: false, data: { error: (e && e.name==='AbortError')? 'timeout' : String(e) }, status: 0 };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function closeRecordModal(){
+  const modal = document.getElementById('recordModal');
+  if(modal) modal.style.display='none';
+}
+
+function resetRecordForm(){
+  const form = document.getElementById('recordForm');
+  if(!form) return;
+  form.reset();
+  REC_STATE.selectedImages = [];
+  const list = document.getElementById('selectedImagesList'); if(list) list.innerHTML='';
+  const block = document.getElementById('selectedImagesBlock'); if(block) block.style.display='none';
+  const imgs = document.getElementById('recordImgs'); if(imgs) imgs.innerHTML='';
+  const addBtn = document.getElementById('recordAddImgBtn'); if(addBtn) addBtn.style.display='none';
+  const json = document.getElementById('selectedImagesJson'); if(json) json.value='[]';
+}
+
+function openRecordModal(profileId, path, line){
+  resetRecordForm();
+  const modal = document.getElementById('recordModal');
+  const form = document.getElementById('recordForm');
+  form.elements['profile_id'].value = profileId;
+  form.elements['file_path'].value = path||'';
+  const view = document.getElementById('recordLineView'); if(view) view.value = line||'';
+  setNow(form.elements['event_dt']);
+  modal.style.display='flex';
+}
+
+function openImageRecordModal(profileId, imagePath){
+  resetRecordForm();
+  const modal = document.getElementById('recordModal');
+  const form = document.getElementById('recordForm');
+  form.elements['profile_id'].value = profileId;
+  form.elements['file_path'].value = imagePath||'';
+  const view = document.getElementById('recordLineView'); if(view) view.value = '';
+  const block = document.getElementById('selectedImagesBlock');
+  const list = document.getElementById('selectedImagesList');
+  if(block) block.style.display='block';
+  if(list){
+    const t = document.createElement('div'); t.className='thumb';
+    const im = document.createElement('img'); im.src = `/api/profiles/${profileId}/image?path=${encodeURIComponent(imagePath)}`; t.appendChild(im);
+    const meta = document.createElement('div'); meta.className='meta';
+    const si = document.createElement('span'); si.className='idx'; si.textContent = '#1'; meta.appendChild(si);
+    const vb = document.createElement('button'); vb.type='button'; vb.textContent='View'; vb.onclick=()=>{ openImageViewer([im.src],0); }; meta.appendChild(vb);
+    t.appendChild(meta); list.appendChild(t);
+  }
+  REC_STATE.selectedImages = [imagePath];
+  const json = document.getElementById('selectedImagesJson'); if(json) json.value = JSON.stringify(REC_STATE.selectedImages);
+  setNow(form.elements['event_dt']);
+  modal.style.display='flex';
+}
+
+function openRecordDetail(rec){
+  resetRecordForm();
+  const modal = document.getElementById('recordModal');
+  const form = document.getElementById('recordForm');
+  form.elements['id'].value = rec.id;
+  form.elements['profile_id'].value = rec.profile_id||'';
+  form.elements['file_path'].value = rec.file_path||'';
+  form.elements['title'].value = rec.title||'';
+  form.elements['situation'].value = rec.situation||'';
+  form.elements['description'].value = rec.description||'';
+  const view = document.getElementById('recordLineView'); if(view) view.value = rec.content||'';
+  if(rec.event_time){ const dt = new Date(rec.event_time*1000); form.elements['event_dt'].value = new Date(dt.getTime()-dt.getTimezoneOffset()*60000).toISOString().slice(0,16); }
+  const grid = document.getElementById('recordImgs');
+  const addBtn = document.getElementById('recordAddImgBtn'); if(addBtn) addBtn.style.display='inline-block';
+  if(grid){
+    (rec.images||[]).forEach(img=>{
+      const wrap = document.createElement('div'); wrap.className='thumb';
+      wrap.innerHTML = `<img src="${img.url||img.path}" loading="lazy"><div class="meta"><span class="idx">#${img.id}</span><button type="button" data-act="imgview" data-src="${img.url||img.path}">View</button><button type="button" data-act="imgdel" data-id="${img.id}" style="border-color:#991b1b">Remove</button></div>`;
+      grid.appendChild(wrap);
+    });
+  }
+  modal.style.display='flex';
+}
+
+document.addEventListener('DOMContentLoaded', ()=>{
+  const form = document.getElementById('recordForm');
+  const cancelBtns = document.querySelectorAll('.record-close');
+  cancelBtns.forEach(btn=> btn.addEventListener('click', closeRecordModal));
+  if(form){
+    form.addEventListener('submit', async (e)=>{
+      e.preventDefault();
+      const fd = new FormData(form);
+      const payload = {
+        profile_id: Number(fd.get('profile_id')||0),
+        title: String(fd.get('title')||''),
+        file_path: String(fd.get('file_path')||''),
+        filter: '',
+        content: String(fd.get('content')||''),
+        situation: String(fd.get('situation')||''),
+        event_time: (function(){ const dt = fd.get('event_dt'); if(!dt) return null; const t = Date.parse(dt); return isNaN(t)? null : Math.floor(t/1000); })(),
+        description: String(fd.get('description')||''),
+      };
+      const rid = fd.get('id');
+      let rec = null;
+      if(rid){
+        const r = await fetch(`/api/records/${rid}`, { method:'PUT', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload) });
+        if(!r.ok){ alert('Save failed'); return; }
+        rec = await r.json();
+      } else {
+        const r = await fetch('/api/records', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload) });
+        if(!r.ok){ alert('Failed to save record'); return; }
+        rec = await r.json();
+        try{
+          const imgsSel = JSON.parse(document.getElementById('selectedImagesJson').value||'[]');
+          for(const rp of imgsSel){
+            await fetch(`/api/records/${rec.id}/image_remote`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ profile_id: payload.profile_id, path: rp }) });
+          }
+        }catch{}
+        const files = (document.querySelector('#recordForm input[name="images"]').files)||[];
+        for(const f of files){ const fdf = new FormData(); fdf.append('file', f); await fetch(`/api/records/${rec.id}/image`, { method:'POST', body: fdf }); }
+      }
+      closeRecordModal();
+      window.dispatchEvent(new CustomEvent('recordSaved', {detail: rec}));
+      alert('Record saved');
+    });
+  }
+  const imgGrid = document.getElementById('recordImgs');
+  if(imgGrid){
+    imgGrid.addEventListener('click', async (e)=>{
+      const btn = e.target.closest('button'); if(!btn) return;
+      if(btn.dataset.act==='imgview'){
+        const urls = [...imgGrid.querySelectorAll('img')].map(im=> im.getAttribute('src'));
+        const src = btn.dataset.src; const idx = urls.indexOf(src);
+        openImageViewer(urls, idx>=0?idx:0);
+        return;
+      }
+      if(btn.dataset.act==='imgdel'){
+        const iid = btn.dataset.id; const r = await fetch(`/api/record_images/${iid}`, { method:'DELETE' });
+        if(r.ok){ closeRecordModal(); window.dispatchEvent(new CustomEvent('recordSaved', {})); }
+      }
+    });
+  }
+  const addBtn = document.getElementById('recordAddImgBtn');
+  if(addBtn){
+    addBtn.addEventListener('click', async ()=>{
+      const rid = document.getElementById('recordForm').elements['id'].value;
+      const files = document.getElementById('recordAddImg').files||[];
+      if(!files.length) return;
+      for(const f of files){ const fd = new FormData(); fd.append('file', f); await fetch(`/api/records/${rid}/image`, { method:'POST', body: fd }); }
+      alert('Images added');
+      closeRecordModal();
+      window.dispatchEvent(new CustomEvent('recordSaved', {detail:{id:rid}}));
+    });
+  }
+});

--- a/app/templates/_record_modal.html
+++ b/app/templates/_record_modal.html
@@ -1,0 +1,45 @@
+<div id="recordModal" class="modal">
+  <div class="content">
+    <h3 id="recordModalTitle">Record</h3>
+    <form id="recordForm">
+      <input type="hidden" name="id" />
+      <input type="hidden" name="profile_id" />
+      <input type="hidden" name="selected_images_json" id="selectedImagesJson" />
+      <label>Path
+        <input type="text" name="file_path" readonly style="width:100%" />
+      </label>
+      <label>Title
+        <input type="text" name="title" placeholder="Optional title" style="width:100%" />
+      </label>
+      <div class="grid" style="grid-template-columns:1fr 1fr; gap:10px;">
+        <label>Date/Time
+          <input type="datetime-local" name="event_dt" />
+        </label>
+        <label>Situation
+          <input type="text" name="situation" placeholder="e.g., Incident, Debug, Note" />
+        </label>
+      </div>
+      <label>Description
+        <textarea name="description" placeholder="Describe context or steps" style="width:100%;height:80px"></textarea>
+      </label>
+      <label>Logs
+        <textarea id="recordLineView" name="content" placeholder="Log lines (for text records)" style="width:100%;height:100px"></textarea>
+      </label>
+      <div>
+        <strong>Images</strong>
+        <div id="recordImgs" style="display:grid; grid-template-columns: repeat(auto-fill, 120px); gap:8px; margin:8px 0;"></div>
+        <div id="selectedImagesBlock" style="display:none; margin:6px 0;">
+          <div id="selectedImagesList" class="panel" style="max-height:180px; overflow:auto"></div>
+        </div>
+        <div style="margin-top:6px;">
+          <input type="file" name="images" id="recordAddImg" multiple accept="image/*" />
+          <button type="button" id="recordAddImgBtn" style="display:none">Add Images</button>
+        </div>
+      </div>
+      <div class="actions">
+        <button type="button" class="record-close">Cancel</button>
+        <button type="submit">Save</button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -48,48 +48,7 @@
       </section>
     </main>
     <!-- Record Modal -->
-    <div id="recordModal" class="modal">
-      <div class="content">
-        <h3>Save Record</h3>
-        <form id="recordForm">
-          <input type="hidden" name="profile_id" />
-          <input type="hidden" name="selected_images_json" id="selectedImagesJson" />
-          <label>Path
-            <input type="text" name="file_path" readonly style="width:100%" />
-          </label>
-          <label>Title
-            <input type="text" name="title" placeholder="Optional title" style="width:100%" />
-          </label>
-          <div class="grid" style="grid-template-columns:1fr 1fr; gap:10px;">
-            <label>Date/Time
-              <input type="datetime-local" name="event_dt" />
-            </label>
-            <label>Situation
-              <input type="text" name="situation" placeholder="e.g., Incident, Debug, Note" />
-            </label>
-          </div>
-          <label>Description
-            <textarea name="description" placeholder="Describe context or steps" style="width:100%;height:80px"></textarea>
-          </label>
-          <label>Logs
-            <textarea id="recordLineView" name="content" placeholder="Log lines (for text records)" style="width:100%;height:100px"></textarea>
-          </label>
-          <div>
-            <strong>Images</strong>
-            <div id="selectedImagesBlock" style="display:none; margin:6px 0;">
-              <div id="selectedImagesList" class="panel" style="max-height:180px; overflow:auto"></div>
-            </div>
-            <div style="margin-top:6px;">
-              <input type="file" name="images" multiple accept="image/*" />
-            </div>
-          </div>
-          <div class="actions">
-            <button type="button" id="recordCancel">Cancel</button>
-            <button type="submit">Save</button>
-          </div>
-        </form>
-      </div>
-    </div>
+    {% include '_record_modal.html' %}
     <!-- Fullscreen Image Viewer -->
     <div id="imgViewer" class="img-viewer">
       <div class="inner">
@@ -112,6 +71,7 @@
     <script>
       window.APP_CFG = {{ (app_cfg or {'apiTimeoutMs':30000}) | tojson }};
     </script>
+    <script src="/static/record-modal.js"></script>
     <script src="/static/app.js"></script>
   </body>
-  </html>
+</html>

--- a/app/templates/records.html
+++ b/app/templates/records.html
@@ -54,40 +54,8 @@
       </div>
     </div>
     <!-- Record Detail Modal -->
-    <div id="recModal" class="modal">
-      <div class="content">
-        <h3>Record Detail</h3>
-        <form id="recForm">
-          <input type="hidden" name="id" />
-          <div class="grid" style="grid-template-columns:1fr 1fr; gap:10px;">
-            <label>Title
-              <input type="text" name="title" />
-            </label>
-            <label>Date/Time
-              <input type="datetime-local" name="event_dt" />
-            </label>
-          </div>
-          <label>Situation
-            <input type="text" name="situation" />
-          </label>
-          <label>Description
-            <textarea name="description" style="width:100%;height:90px"></textarea>
-          </label>
-          <div>
-            <strong>Images</strong>
-            <div id="recImgs" style="display:grid; grid-template-columns: repeat(auto-fill, 120px); gap:8px; margin:8px 0;"></div>
-            <div>
-              <input type="file" id="recAddImg" multiple accept="image/*" />
-              <button type="button" id="recAddImgBtn">Add Images</button>
-            </div>
-          </div>
-          <div class="actions">
-            <button type="button" id="recClose">Close</button>
-            <button type="submit">Save</button>
-          </div>
-        </form>
-      </div>
-    </div>
+    {% include '_record_modal.html' %}
+    <script src="/static/record-modal.js"></script>
     <script>
       window.APP_CFG = {{ (app_cfg or {'apiTimeoutMs':30000}) | tojson }};
       // mark active nav
@@ -127,7 +95,7 @@
             const situation = rec.situation||'';
             const desc = (rec.description||'').replace(/</g,'&lt;').replace(/>/g,'&gt;');
             tr.innerHTML = `<td>${rec.id}</td><td>${pm[rec.profile_id]||''}</td><td>${rec.file_path||''}</td><td>${logs}</td><td>${rec.title||''}</td><td>${situation}</td><td>${desc}</td><td>${imgs}</td><td>${situationDate}</td><td>${created}</td><td><button data-act=\"del\" data-id=\"${rec.id}\" style=\"border-color:#991b1b\">Delete</button></td>`;
-            tr.addEventListener('click', (ev)=>{ if(ev.target.closest('button')) return; openDetail(rec); });
+            tr.addEventListener('click', (ev)=>{ if(ev.target.closest('button')) return; openRecordDetail(rec); });
             tb.appendChild(tr);
           });
       }
@@ -139,59 +107,9 @@
           if(r.ok){ load(); } else { alert('Delete failed'); }
         }
       });
-      function openDetail(rec){
-        const modal = document.getElementById('recModal');
-        const form = document.getElementById('recForm');
-        form.elements['id'].value = rec.id;
-        if(form.elements['path_ro']) form.elements['path_ro'].value = rec.file_path||'';
-        form.elements['title'].value = rec.title||'';
-        form.elements['situation'].value = rec.situation||'';
-        form.elements['description'].value = rec.description||'';
-        if(rec.event_time){ const dt = new Date(rec.event_time*1000); form.elements['event_dt'].value = new Date(dt.getTime()-dt.getTimezoneOffset()*60000).toISOString().slice(0,16); } else { form.elements['event_dt'].value=''; }
-        const grid = document.getElementById('recImgs'); grid.innerHTML='';
-        (rec.images||[]).forEach(img=>{
-          const wrap = document.createElement('div'); wrap.className='thumb';
-          wrap.innerHTML = `<img src="${img.url||img.path}" loading="lazy"><div class="meta"><span class="idx">#${img.id}</span><button type="button" data-act="imgview" data-src="${img.url||img.path}">View</button><button type="button" data-act="imgdel" data-id="${img.id}" style="border-color:#991b1b">Remove</button></div>`;
-          grid.appendChild(wrap);
-        });
-        modal.style.display='flex';
-      }
-      document.getElementById('recClose').addEventListener('click', ()=>{ document.getElementById('recModal').style.display='none'; });
-      document.getElementById('recForm').addEventListener('submit', async (e)=>{
-        e.preventDefault();
-        const f = e.target;
-        const payload = {
-          title: f.elements['title'].value,
-          situation: f.elements['situation'].value,
-          description: f.elements['description'].value,
-          event_time: (function(){ const v=f.elements['event_dt'].value; if(!v) return null; const t=Date.parse(v); return isNaN(t)? null : Math.floor(t/1000); })(),
-        };
-        const rid = f.elements['id'].value;
-        const r = await fetch(`/api/records/${rid}`, { method:'PUT', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload) });
-        if(r.ok){ alert('Saved'); document.getElementById('recModal').style.display='none'; load(); } else { alert('Save failed'); }
-      });
-      document.getElementById('recImgs').addEventListener('click', async (e)=>{
-        const btn = e.target.closest('button'); if(!btn) return;
-        if(btn.dataset.act==='imgview'){
-          const grid = document.getElementById('recImgs');
-          const urls = [...grid.querySelectorAll('img')].map(im=> im.getAttribute('src'));
-          const src = btn.dataset.src; const idx = urls.indexOf(src);
-          openImageViewer(urls, idx>=0?idx:0);
-          return;
-        }
-        if(btn.dataset.act==='imgdel'){
-          const iid = btn.dataset.id; const r = await fetch(`/api/record_images/${iid}`, { method:'DELETE' });
-          if(r.ok){ load(); document.getElementById('recModal').style.display='none'; }
-        }
-      });
-      document.getElementById('recAddImgBtn').addEventListener('click', async ()=>{
-        const input = document.getElementById('recAddImg'); const rid = document.getElementById('recForm').elements['id'].value;
-        const files = input.files||[]; if(!files.length) return;
-        for(const f of files){ const fd = new FormData(); fd.append('file', f); await fetch(`/api/records/${rid}/image`, { method:'POST', body: fd }); }
-        alert('Images added'); document.getElementById('recModal').style.display='none'; load();
-      });
       document.getElementById('profileSelect').addEventListener('change', (e)=>{ PROFILE_ID = e.target.value; setPref('records.PROFILE_ID', PROFILE_ID); load(); });
       (async ()=>{ await loadProfiles(); await load(); })();
+      window.addEventListener('recordSaved', ()=>{ load(); });
       // viewer fn (shared with Logs page)
       let IMG_VIEW = { arr: [], idx: 0 };
       function openImageViewer(arr, start){

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -26,11 +26,13 @@ CTX_PRIORITY_MODE: recent-first
 │  ├─ db.py                    # SQLite init/access (profiles, paths, records, images)
 │  ├─ views.py                 # Web views: /, /profiles, /records
 │  ├─ templates/
+│  │  ├─ _record_modal.html   # Reusable record form modal
 │  │  ├─ index.html            # Logs page (SPA shell)
 │  │  ├─ profiles.html         # Profiles management (SSH/FTP)
 │  │  └─ records.html          # Records browse/upload
 │  └─ static/
 │     ├─ app.js                # Logs page UI logic
+│     ├─ record-modal.js       # Record form modal widget
 │     └─ style.css             # Styles
 ├─ docs/
 │  ├─ env.md

--- a/docs/module-architecture.md
+++ b/docs/module-architecture.md
@@ -27,7 +27,9 @@ graph TD
     T[templates/index.html]
     TP[templates/profiles.html]
     TR[templates/records.html]
+    TM[templates/_record_modal.html]
     S[static/app.js]
+    RM[static/record-modal.js]
     CSS[static/style.css]
   end
 
@@ -42,6 +44,10 @@ graph TD
   F --> T
   F --> TP
   F --> TR
+  T --> TM
+  TR --> TM
+  T --> RM
+  TR --> RM
   T --> S
   T --> CSS
   TP --> CSS


### PR DESCRIPTION
## Summary
- extract a reusable record modal partial used across pages
- move record form logic into a portable `record-modal.js` widget
- update docs to include new modal component

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b475e1160c8320bd7f708db60d16d1